### PR TITLE
Fix logstash plugin tasks chdir usage

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,15 +1,15 @@
 ---
 - name: Get list of installed plugins.
-  command: >
-    ./bin/logstash-plugin list
-    chdir={{ logstash_dir }}
+  command: ./bin/logstash-plugin list
+  args:
+    chdir: "{{ logstash_dir }}"
   register: logstash_plugins_list
   changed_when: false
 
 - name: Install configured plugins.
-  command: >
-    ./bin/logstash-plugin install {{ item }}
-    chdir={{ logstash_dir }}
+  command: ./bin/logstash-plugin install {{ item }}
+  args:
+    chdir: "{{ logstash_dir }}"
   with_items: "{{ logstash_install_plugins }}"
   when: "item not in logstash_plugins_list.stdout"
   notify: restart logstash


### PR DESCRIPTION
## Summary
- fix plugin installation tasks to use args.chdir instead of concatenated chdir path

## Testing
- `ansible-lint`
- `yamllint .`
- `molecule test` *(fails: Failed to find driver docker)*

------
https://chatgpt.com/codex/tasks/task_e_68a69f40e0c48321bba7953dc7ac3f85